### PR TITLE
Removed the ocp-mini-stack repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,8 +38,6 @@ repositories:
   categories: [ ocp_install, ocp_config, ocp_workloads ]
 - url: https://github.com/chuckersjp/coreos-iso-maker
   categories: [ ocp_install ]
-- url: https://github.com/containercraft/ocp-mini-stack
-  categories: [ ocp_install ]
 - url:  https://github.com/gnunn-gitops/cluster-config-acm
   categories: [ ocp_config ]
 - url: https://github.com/darthlukan/gitops-workshop


### PR DESCRIPTION
This repo is no longer in Github so I've removed it from the config.yaml file