### PR TITLE
Add a new ossm repository

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -260,6 +260,8 @@ repositories:
   categories: [ ocp_install ]
 - url: https://github.com/wpernath/openshift-config
   categories: [ ocp_config ]
+- url: https://github.com/fperearodriguez/service-mesh-workshop
+  categories: [ ossm ]
 
 #Repository('https://gitlab.consulting.redhat.com/nordics/ocp4-vmware-upi-prep', [Category.OCP_INSTALL])
 #Repository('https://gitlab.consulting.redhat.com/jnaess/ocp4-prereqs', [Category.OCP_INSTALL])

--- a/config.yaml
+++ b/config.yaml
@@ -78,6 +78,8 @@ repositories:
   categories: [ ocp_disconnected ]
 - url: https://github.com/elajoie/lab.local
   categories: [ ocp_install ]
+- url: https://github.com/fperearodriguez/service-mesh-workshop
+  categories: [ ossm ]
 - url: https://github.com/hybrid-cloud-patterns/multicloud-gitops
   categories: [ ocp_gitops, rhacm ]
 - url: https://github.com/giannisalinetti/rhacs-operator-demo
@@ -260,8 +262,6 @@ repositories:
   categories: [ ocp_install ]
 - url: https://github.com/wpernath/openshift-config
   categories: [ ocp_config ]
-- url: https://github.com/fperearodriguez/service-mesh-workshop
-  categories: [ ossm ]
 
 #Repository('https://gitlab.consulting.redhat.com/nordics/ocp4-vmware-upi-prep', [Category.OCP_INSTALL])
 #Repository('https://gitlab.consulting.redhat.com/jnaess/ocp4-prereqs', [Category.OCP_INSTALL])


### PR DESCRIPTION
Added a new repository about Red Hat OpenShift Service Mesh. In this repository, you can find some files to prepare the OCP cluster, how to install the RHOSSM and how to configure RHOSSM for multiple users.

In addition to this, a full workshop is described: Deploy a sample application, expose the application (Istio Ingress and Egress usage), traffic management, and security tasks.