### PR TITLE
added gitops repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -176,6 +176,8 @@ repositories:
   categories: [ rhacs ]
 - url: https://github.com/rcarrata/rhacs-gitops
   categories: [ rhacs ]
+- url: https://github.com/romerobu/manual-workshop-infra
+  categories: [ ocp_gitops ]
 - url: https://github.com/RedHatOfficial/ocp4-helpernode
   categories: [ ocp_install ]
 - url: https://github.com/red-hat-storage/ocs-ci

--- a/config.yaml
+++ b/config.yaml
@@ -176,8 +176,6 @@ repositories:
   categories: [ rhacs ]
 - url: https://github.com/rcarrata/rhacs-gitops
   categories: [ rhacs ]
-- url: https://github.com/romerobu/manual-workshop-infra
-  categories: [ ocp_gitops ]
 - url: https://github.com/RedHatOfficial/ocp4-helpernode
   categories: [ ocp_install ]
 - url: https://github.com/red-hat-storage/ocs-ci
@@ -216,6 +214,8 @@ repositories:
   categories: [ ocp_install ]
 - url: https://github.com/RHFieldProductManagement/baremetal-ipi-lab
   categories: [ ocp_install ]
+- url: https://github.com/romerobu/manual-workshop-infra
+  categories: [ ocp_gitops ]  
 - url: https://github.com/sa-mw-dach/ocp-on-kvm
   categories: [ ocp_install ]
 - url: https://github.com/sa-ne/openshift4-rhv-upi


### PR DESCRIPTION
I  added a new repo about Openshift GitOps deployment and configuration plus managing infra configurations.

This repo is a workshop intended to deploy an environment on AWS with multiple managed single nodes cluster for so many users as the workshop delivery requires.
Repository linked (https://github.com/romerobu/manual-workshop-infra) is a manual with all the instructions needed for delivery. Therefore in the readme section you can find the repo used for lab environment deployment and configuration (setup).